### PR TITLE
fix tv series no data

### DIFF
--- a/Jellyfin.Plugin.Fanart/Providers/SeriesProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/SeriesProvider.cs
@@ -73,7 +73,7 @@ namespace Jellyfin.Plugin.Fanart.Providers
 
             var series = (Series)item;
 
-            var id = series.GetProviderId(MetadataProvider.Tmdb) ?? series.GetProviderId(MetadataProvider.Tvdb);
+            var id = series.GetProviderId(MetadataProvider.Tvdb);
 
             if (!string.IsNullOrEmpty(id))
             {


### PR DESCRIPTION
Fanart's TV series use tvdb ID by default, rather than tmdb ID