### PR TITLE
Link to wiki for API key information

### DIFF
--- a/Jellyfin.Plugin.Fanart/Web/fanart.html
+++ b/Jellyfin.Plugin.Fanart/Web/fanart.html
@@ -6,7 +6,7 @@
                     <input is="emby-input" type="text" id="apikey" name="apikey" label="Personal API Key" />
                     <div class="fieldDescription">Requests to fanart without a personal API key return images that were approved over seven days ago. If you include a personal API key your queries will return images approved more than two days ago and if you are also a VIP member at Fanart that value will drop to around ten minutes.</div>
                     <div class="fieldDescription">
-                        <a is="emby-linkbutton" class="button-link" href="https://fanart.tv/2015/01/personal-api-keys" target="_blank">${ButtonLearnMore}</a>
+                        <a is="emby-linkbutton" class="button-link" href="https://wiki.fanart.tv/General/personal%20api/" target="_blank">${ButtonLearnMore}</a>
                     </div>
                 </div>
                 <div>


### PR DESCRIPTION
- Old link ended in a 404
- Link to API page has only login and register info
- Wiki provides a background a link to registration

resolves https://github.com/jellyfin/jellyfin-plugin-fanart/issues/44