### PR TITLE
Guess correct Thumb image size

### DIFF
--- a/Jellyfin.Plugin.Fanart/Dtos/ArtistImage.cs
+++ b/Jellyfin.Plugin.Fanart/Dtos/ArtistImage.cs
@@ -10,6 +10,15 @@ namespace Jellyfin.Plugin.Fanart.Dtos
         [JsonPropertyName("url")]
         public string Url { get; set; }
 
+        [JsonPropertyName("width")]
+        public int Width { get; set; }
+
+        [JsonPropertyName("height")]
+        public int Height { get; set; }
+
+        [JsonPropertyName("added")]
+        public string Added { get; set; }
+
         [JsonPropertyName("likes")]
         public string Likes { get; set; }
 

--- a/Jellyfin.Plugin.Fanart/Dtos/MovieImage.cs
+++ b/Jellyfin.Plugin.Fanart/Dtos/MovieImage.cs
@@ -10,6 +10,15 @@ namespace Jellyfin.Plugin.Fanart.Dtos
         [JsonPropertyName("url")]
         public string Url { get; set; }
 
+        [JsonPropertyName("width")]
+        public int Width { get; set; }
+
+        [JsonPropertyName("height")]
+        public int Height { get; set; }
+
+        [JsonPropertyName("added")]
+        public string Added { get; set; }
+
         [JsonPropertyName("lang")]
         public string Language { get; set; }
 

--- a/Jellyfin.Plugin.Fanart/Dtos/SeriesImage.cs
+++ b/Jellyfin.Plugin.Fanart/Dtos/SeriesImage.cs
@@ -11,6 +11,15 @@ namespace Jellyfin.Plugin.Fanart.Dtos
         [JsonPropertyName("url")]
         public string Url { get; set; }
 
+        [JsonPropertyName("width")]
+        public int Width { get; set; }
+
+        [JsonPropertyName("height")]
+        public int Height { get; set; }
+
+        [JsonPropertyName("added")]
+        public string Added { get; set; }
+
         [JsonPropertyName("lang")]
         public string Language { get; set; }
 

--- a/Jellyfin.Plugin.Fanart/Providers/SeasonProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/SeasonProvider.cs
@@ -138,7 +138,7 @@ namespace Jellyfin.Plugin.Fanart.Providers
         {
             PopulateImages(list, obj.SeasonPosters, ImageType.Primary, 1000, 1426, seasonNumber);
             PopulateImages(list, obj.SeasonBanners, ImageType.Banner, 1000, 185, seasonNumber);
-            PopulateImages(list, obj.SeasonThumbs, ImageType.Thumb, 500, 281, seasonNumber);
+            PopulateImages(list, obj.SeasonThumbs, ImageType.Thumb, 1000, 562, seasonNumber);
             PopulateImages(list, obj.Showbackgrounds, ImageType.Backdrop, 1920, 1080, seasonNumber);
         }
 
@@ -182,6 +182,11 @@ namespace Jellyfin.Plugin.Fanart.Providers
                         && int.TryParse(likesString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var likes))
                     {
                         info.CommunityRating = likes;
+                    }
+
+                    if (type == ImageType.Thumb && DateTime.Parse(i.Added,  null) < new DateTime(2016,1,1)) {
+                        info.Width = 500;
+                        info.Height = 281;
                     }
 
                     return info;

--- a/Jellyfin.Plugin.Fanart/Providers/SeriesProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/SeriesProvider.cs
@@ -154,7 +154,7 @@ namespace Jellyfin.Plugin.Fanart.Providers
             PopulateImages(list, obj.ClearArts, ImageType.Art, 500, 281);
             PopulateImages(list, obj.Showbackgrounds, ImageType.Backdrop, 1920, 1080, true);
             PopulateImages(list, obj.SeasonThumbs, ImageType.Thumb, 500, 281);
-            PopulateImages(list, obj.TvThumbs, ImageType.Thumb, 500, 281);
+            PopulateImages(list, obj.TvThumbs, ImageType.Thumb, 1000, 562);
             PopulateImages(list, obj.TvBanners, ImageType.Banner, 1000, 185);
             PopulateImages(list, obj.TvPosters, ImageType.Primary, 1000, 1426);
         }
@@ -199,6 +199,11 @@ namespace Jellyfin.Plugin.Fanart.Providers
                         && int.TryParse(likesString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var likes))
                     {
                         info.CommunityRating = likes;
+                    }
+
+                    if (type == ImageType.Thumb && DateTime.Parse(i.Added,  null) < new DateTime(2016,1,1)) {
+                        info.Width = 500;
+                        info.Height = 281;
                     }
 
                     return info;

--- a/Jellyfin.Plugin.Fanart/Providers/SeriesProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/SeriesProvider.cs
@@ -201,7 +201,7 @@ namespace Jellyfin.Plugin.Fanart.Providers
                         info.CommunityRating = likes;
                     }
 
-                    if (type == ImageType.Thumb && DateTime.Parse(i.Added,  null) < new DateTime(2016,1,1)) {
+                    if (type == ImageType.Thumb && DateTime.Parse(i.Added,  null) < new DateTime(2016,1,8)) {
                         info.Width = 500;
                         info.Height = 281;
                     }


### PR DESCRIPTION
Current 3.2 and Fanart DB has some wrong info, reason to avoid width and height for now. Fanart trys to improves this info so the Date and fixes sizes can be removed at some point.

Fixes #46 