### PR TITLE
Adjust structure of the classes to v3.2 response

### DIFF
--- a/Jellyfin.Plugin.Fanart/Dtos/Album.cs
+++ b/Jellyfin.Plugin.Fanart/Dtos/Album.cs
@@ -5,6 +5,10 @@ namespace Jellyfin.Plugin.Fanart.Dtos
 {
     public class Album
     {
+        [JsonPropertyName("release_group_id")]
+        public string ReleaseGroupId { get; set; }
+
+
         [JsonPropertyName("cdart")]
         public List<ArtistImage> CdArts { get; set; }
 

--- a/Jellyfin.Plugin.Fanart/Dtos/ArtistResponse.cs
+++ b/Jellyfin.Plugin.Fanart/Dtos/ArtistResponse.cs
@@ -33,6 +33,6 @@ namespace Jellyfin.Plugin.Fanart.Dtos
         public List<ArtistImage> HdmusicArts { get; set; }
 
         [JsonPropertyName("albums")]
-        public Dictionary<string, Album> Albums { get; set; }
+        public List<Album> Albums { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Fanart/Providers/AlbumProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/AlbumProvider.cs
@@ -136,9 +136,9 @@ namespace Jellyfin.Plugin.Fanart.Providers
 
             if (obj.Albums != null)
             {
-                var album = obj.Albums.FirstOrDefault(i => string.Equals(i.Key, releaseId, StringComparison.OrdinalIgnoreCase) || string.Equals(i.Key, releaseGroupId, StringComparison.OrdinalIgnoreCase));
-                var albumcovers = album.Value.AlbumCovers;
-                var cdarts = album.Value.CdArts;
+                var album = obj.Albums.FirstOrDefault(i => string.Equals(i.ReleaseGroupId, releaseId, StringComparison.OrdinalIgnoreCase) || string.Equals(i.ReleaseGroupId, releaseGroupId, StringComparison.OrdinalIgnoreCase));
+                var albumcovers = album?.AlbumCovers;
+                var cdarts = album?.CdArts;
 
                 if (albumcovers != null)
                 {


### PR DESCRIPTION
Changed structure of classes to correspond to the v3.2 of fanart API.

Since documentation for 3.2 is not available, change assumes that what was previously a key in dictionary of albums is now field `release_group_id` inside each album object and can be used in exactly the same capacity.