### PR TITLE
Use preview  image for faster loading times

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "github>jellyfin/.github//renovate-presets/default"
+        "github>jellyfin/.github//renovate-presets/plugin"
     ]
 }

--- a/Jellyfin.Plugin.Fanart/Providers/AlbumProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/AlbumProvider.cs
@@ -209,7 +209,8 @@ public class AlbumProvider : IRemoteImageProvider, IHasOrder
                     Width = width,
                     Height = height,
                     ProviderName = Name,
-                    Url = url.Replace("http://", "https://", StringComparison.OrdinalIgnoreCase),
+                    ThumbnailUrl = url.Replace("/fanart/", "/bigpreview/", StringComparison.OrdinalIgnoreCase),
+                    Url = url,
                     Language = language
                 };
 

--- a/Jellyfin.Plugin.Fanart/Providers/ArtistProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/ArtistProvider.cs
@@ -201,7 +201,8 @@ public class ArtistProvider : IRemoteImageProvider, IHasOrder
                     Width = width,
                     Height = height,
                     ProviderName = Name,
-                    Url = url.Replace("http://", "https://", StringComparison.OrdinalIgnoreCase),
+                    ThumbnailUrl = url.Replace("/fanart/", "/bigpreview/", StringComparison.OrdinalIgnoreCase),
+                    Url = url,
                     Language = language
                 };
 

--- a/Jellyfin.Plugin.Fanart/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/MovieProvider.cs
@@ -205,6 +205,7 @@ public class MovieProvider : IRemoteImageProvider, IHasOrder
                     Width = width,
                     Height = height,
                     ProviderName = Name,
+                    ThumbnailUrl = url.Replace("/fanart/", "/bigpreview/", StringComparison.OrdinalIgnoreCase),
                     Url = url,
                     Language = language
                 };

--- a/Jellyfin.Plugin.Fanart/Providers/SeasonProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/SeasonProvider.cs
@@ -203,7 +203,8 @@ public class SeasonProvider : IRemoteImageProvider, IHasOrder
                     Width = width,
                     Height = height,
                     ProviderName = Name,
-                    Url = url.Replace("http://", "https://", StringComparison.OrdinalIgnoreCase),
+                    ThumbnailUrl = url.Replace("/fanart/", "/bigpreview/", StringComparison.OrdinalIgnoreCase),
+                    Url = url,
                     Language = language
                 };
 

--- a/Jellyfin.Plugin.Fanart/Providers/SeriesProvider.cs
+++ b/Jellyfin.Plugin.Fanart/Providers/SeriesProvider.cs
@@ -218,7 +218,8 @@ public class SeriesProvider : IRemoteImageProvider, IHasOrder, IDisposable
                     Width = width,
                     Height = height,
                     ProviderName = Name,
-                    Url = url.Replace("http://", "https://", StringComparison.OrdinalIgnoreCase),
+                    ThumbnailUrl = url.Replace("/fanart/", "/bigpreview/", StringComparison.OrdinalIgnoreCase),
+                    Url = url,
                     Language = language
                 };
 


### PR DESCRIPTION
Fanart has 2 thumbs and one original, and it often loads slow, especially a page of posters. So use preview option.

Example 
```
17kb 200x285 - preview
54kb 400x570 - bigpreview
1mb  1000x1474 - fanart (original)
```

Other images seem to be all 400 width x ratio. Smaller image is maybe to small depending on DPI and biggest gain is to preview. Went into every category provided, and it worked (including old sizes)

Also unify https - with API v3.2 every URL returns https